### PR TITLE
Add support for net core2.1

### DIFF
--- a/src/Amazon.SecretsManager.Extensions.Caching/Amazon.SecretsManager.Extensions.Caching.csproj
+++ b/src/Amazon.SecretsManager.Extensions.Caching/Amazon.SecretsManager.Extensions.Caching.csproj
@@ -5,6 +5,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>..\..\code-analysis.ruleset</CodeAnalysisRuleSet>
     <OutputType>Library</OutputType>
+    <Version>1.0.4</Version>
+    <PackageReleaseNotes>- Added support for .NET Core 2.1</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Amazon.SecretsManager.Extensions.Caching/Amazon.SecretsManager.Extensions.Caching.csproj
+++ b/src/Amazon.SecretsManager.Extensions.Caching/Amazon.SecretsManager.Extensions.Caching.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.SecretsManager" Version="3.3.100.10" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Amazon.SecretsManager.Extensions.Caching/ISecretsManagerCache.cs
+++ b/src/Amazon.SecretsManager.Extensions.Caching/ISecretsManagerCache.cs
@@ -1,0 +1,37 @@
+﻿namespace Amazon.SecretsManager.Extensions.Caching
+{
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Interface for interacting with AWS Secrets Manager with added caching.
+    /// </summary>
+    public interface ISecretsManagerCache
+    {
+        /// <summary>
+        /// Asynchronously retrieves the specified SecretString after calling <see cref="GetCachedSecret"/>.
+        /// </summary>
+        /// <param name="secretId">The secret id.</param>
+        Task<string> GetSecretString(string secretId);
+
+        /// <summary>
+        /// Asynchronously retrieves the specified SecretBinary after calling <see cref="GetCachedSecret"/>.
+        /// </summary>
+        /// <param name="secretId">The secret id.</param>
+        Task<byte[]> GetSecretBinary(string secretId);
+
+        /// <summary>
+        /// Requests the secret value from SecretsManager asynchronously and updates the cache entry with any changes.
+        /// If there is no existing cache entry, a new one is created.
+        /// Returns true or false depending on if the refresh is successful.
+        /// </summary>
+        /// <param name="secretId">The secret id.</param>
+        Task<bool> RefreshNowAsync(string secretId);
+
+        /// <summary>
+        /// Returns the cache entry corresponding to the specified secret if it exists in the cache.
+        /// Otherwise, the secret value is fetched from Secrets Manager and a new cache entry is created.
+        /// </summary>
+        /// <param name="secretId">The secret id.</param>
+        SecretCacheItem GetCachedSecret(string secretId);
+    }
+}

--- a/src/Amazon.SecretsManager.Extensions.Caching/SecretsManagerCache.cs
+++ b/src/Amazon.SecretsManager.Extensions.Caching/SecretsManagerCache.cs
@@ -22,7 +22,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
     /// <summary>
     /// A class used for clide-side caching of secrets stored in AWS Secrets Manager
     /// </summary>
-    public class SecretsManagerCache : IDisposable
+    public class SecretsManagerCache : ISecretsManagerCache, IDisposable
     {
         private readonly IAmazonSecretsManager secretsManager;
         private readonly SecretCacheConfiguration config;
@@ -69,7 +69,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
                 sm.BeforeRequestEvent += this.ServiceClientBeforeRequestEvent;
             }
         }
-        
+
         private void ServiceClientBeforeRequestEvent(object sender, RequestEventArgs e)
         {
             if (e is WebServiceRequestEventArgs args && args.Headers.ContainsKey(VersionInfo.USER_AGENT_HEADER))
@@ -84,9 +84,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
             cache.Dispose();
         }
 
-        /// <summary>
-        /// Asynchronously retrieves the specified SecretString after calling <see cref="GetCachedSecret"/>.
-        /// </summary>
+        /// <inheritdoc />
         public async Task<String> GetSecretString(String secretId)
         {
             SecretCacheItem secret = GetCachedSecret(secretId);
@@ -95,9 +93,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
             return response?.SecretString;
         }
 
-        /// <summary>
-        /// Asynchronously retrieves the specified SecretBinary after calling <see cref="GetCachedSecret"/>.
-        /// </summary>
+        /// <inheritdoc />
         public async Task<byte[]> GetSecretBinary(String secretId)
         {
             SecretCacheItem secret = GetCachedSecret(secretId);
@@ -106,20 +102,13 @@ namespace Amazon.SecretsManager.Extensions.Caching
             return response?.SecretBinary?.ToArray();
         }
 
-        /// <summary>
-        /// Requests the secret value from SecretsManager asynchronously and updates the cache entry with any changes.
-        /// If there is no existing cache entry, a new one is created.
-        /// Returns true or false depending on if the refresh is successful.
-        /// </summary>
+        /// <inheritdoc />
         public async Task<bool> RefreshNowAsync(String secretId)
         {
             return await GetCachedSecret(secretId).RefreshNowAsync();
         }
 
-        /// <summary>
-        /// Returns the cache entry corresponding to the specified secret if it exists in the cache.
-        /// Otherwise, the secret value is fetched from Secrets Manager and a new cache entry is created.
-        /// </summary>
+        /// <inheritdoc />
         public SecretCacheItem GetCachedSecret(string secretId)
         {
             SecretCacheItem secret = cache.Get<SecretCacheItem>(secretId);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changed dependency on "Microsoft.Extensions.Caching.Memory" from version 2.2.0 to 2.1.2 so that the package can be consumed in .NET Core 2.1 applications.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
